### PR TITLE
Add prepare script to ensure dist files are generated during deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test": "jest",
     "coverage": "jest --coverage --collectCoverageFrom='./src/**' --verbose && jest-coverage-badges",
     "lint": "tslint -c tslint.json 'src/**/*.ts'",
-    "build": "rm -r -f dist && webpack"
+    "build": "rm -r -f dist && webpack",
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Was getting errors when trying to import and noticed neither the index.js or index.d.ts files were in the node modules/qbem folder - hoping this fixes it for ya